### PR TITLE
feat(auth): SALOONY-26 forgot password api for email using tokens

### DIFF
--- a/src/sections/auth/auth-forms/AuthForgotPassword.tsx
+++ b/src/sections/auth/auth-forms/AuthForgotPassword.tsx
@@ -19,6 +19,7 @@ import { Formik } from 'formik';
 // project imports
 import useScriptRef from 'hooks/useScriptRef';
 import AnimateButton from 'components/@extended/AnimateButton';
+import { useForgotPasswordMutation } from 'store/api/authApi';
 
 import { openSnackbar } from 'api/snackbar';
 
@@ -30,6 +31,7 @@ import { SnackbarProps } from 'types/snackbar';
 export default function AuthForgotPassword() {
   const scriptedRef = useScriptRef();
   const router = useRouter();
+  const [forgotPassword] = useForgotPasswordMutation();
 
   return (
     <Formik
@@ -42,25 +44,29 @@ export default function AuthForgotPassword() {
       })}
       onSubmit={async (values, { setErrors, setStatus, setSubmitting }) => {
         try {
-          setStatus({ success: true });
-          setSubmitting(false);
+          await forgotPassword({ email: values.email }).unwrap();
 
-          openSnackbar({
-            open: true,
-            message: 'Check mail for reset password link',
-            variant: 'alert',
-            alert: {
-              color: 'success'
-            }
-          } as SnackbarProps);
+          if (scriptedRef.current) {
+            setStatus({ success: true });
+            setSubmitting(false);
 
-          setTimeout(() => {
-            router.push('/check-mail');
-          }, 1500);
+            openSnackbar({
+              open: true,
+              message: 'Check mail for reset password link',
+              variant: 'alert',
+              alert: {
+                color: 'success'
+              }
+            } as SnackbarProps);
+
+            setTimeout(() => {
+              router.push('/check-mail?email=' + encodeURIComponent(values.email));
+            }, 1500);
+          }
         } catch (err: any) {
           if (scriptedRef.current) {
             setStatus({ success: false });
-            setErrors({ submit: err.message });
+            setErrors({ submit: err.data?.message ?? 'Something went wrong. Please try again.' });
             setSubmitting(false);
           }
         }

--- a/src/sections/auth/auth-forms/AuthForgotPassword.tsx
+++ b/src/sections/auth/auth-forms/AuthForgotPassword.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
+
 // next
 import { useRouter } from 'next/navigation';
 
@@ -17,21 +19,36 @@ import * as Yup from 'yup';
 import { Formik } from 'formik';
 
 // project imports
-import useScriptRef from 'hooks/useScriptRef';
 import AnimateButton from 'components/@extended/AnimateButton';
 import { useForgotPasswordMutation } from 'store/api/authApi';
-
 import { openSnackbar } from 'api/snackbar';
 
 // types
 import { SnackbarProps } from 'types/snackbar';
 
+type ApiErrorShape = {
+  data?: { message?: string };
+  error?: string;
+  message?: string;
+};
+
+function getErrorMessage(err: unknown): string {
+  const e = err as ApiErrorShape;
+  return e?.data?.message || e?.message || e?.error || 'Something went wrong. Please try again.';
+}
+
 // ============================|| FIREBASE - FORGOT PASSWORD ||============================ //
 
 export default function AuthForgotPassword() {
-  const scriptedRef = useScriptRef();
   const router = useRouter();
+  const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [forgotPassword] = useForgotPasswordMutation();
+
+  useEffect(() => {
+    return () => {
+      if (redirectTimerRef.current) clearTimeout(redirectTimerRef.current);
+    };
+  }, []);
 
   return (
     <Formik
@@ -46,29 +63,24 @@ export default function AuthForgotPassword() {
         try {
           await forgotPassword({ email: values.email }).unwrap();
 
-          if (scriptedRef.current) {
-            setStatus({ success: true });
-            setSubmitting(false);
+          setStatus({ success: true });
 
-            openSnackbar({
-              open: true,
-              message: 'Check mail for reset password link',
-              variant: 'alert',
-              alert: {
-                color: 'success'
-              }
-            } as SnackbarProps);
+          openSnackbar({
+            open: true,
+            message: 'Check your email for the password reset link.',
+            variant: 'alert',
+            alert: { color: 'success' }
+          } as SnackbarProps);
 
-            setTimeout(() => {
-              router.push('/check-mail?email=' + encodeURIComponent(values.email));
-            }, 1500);
-          }
-        } catch (err: any) {
-          if (scriptedRef.current) {
-            setStatus({ success: false });
-            setErrors({ submit: err.data?.message ?? 'Something went wrong. Please try again.' });
-            setSubmitting(false);
-          }
+          const encodedEmail = encodeURIComponent(values.email);
+          redirectTimerRef.current = setTimeout(() => {
+            router.push(`/check-mail?email=${encodedEmail}`);
+          }, 1500);
+        } catch (err) {
+          setStatus({ success: false });
+          setErrors({ submit: getErrorMessage(err) });
+        } finally {
+          setSubmitting(false);
         }
       }}
     >
@@ -102,7 +114,7 @@ export default function AuthForgotPassword() {
               </Grid>
             )}
             <Grid sx={{ mb: -2 }} size={12}>
-              <Typography variant="caption">Do not forgot to check SPAM box.</Typography>
+              <Typography variant="caption">{"Don't forget to check your SPAM folder."}</Typography>
             </Grid>
             <Grid size={12}>
               <AnimateButton>

--- a/src/store/api/authApi.ts
+++ b/src/store/api/authApi.ts
@@ -1,0 +1,28 @@
+// project imports
+import { baseApi } from './baseApi';
+
+// types
+interface ForgotPasswordRequest {
+  email: string;
+}
+
+interface ForgotPasswordResponse {
+  message: string;
+}
+
+// ==============================|| RTK QUERY - AUTH ENDPOINTS ||============================== //
+
+export const authApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    forgotPassword: builder.mutation<ForgotPasswordResponse, ForgotPasswordRequest>({
+      query: (body) => ({
+        url: 'auth/forgot-password',
+        method: 'POST',
+        body
+      })
+    })
+  }),
+  overrideExisting: false
+});
+
+export const { useForgotPasswordMutation } = authApi;

--- a/src/views/auth/check-mail.tsx
+++ b/src/views/auth/check-mail.tsx
@@ -2,6 +2,7 @@
 
 // next
 import NextLink from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 
 // material-ui
@@ -19,9 +20,19 @@ import FirebaseSocial from 'sections/auth/auth-forms/FirebaseSocial';
 
 // ================================|| CHECK MAIL ||================================ //
 
+function maskEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  if (!domain) return email;
+  const masked = local.slice(0, 2) + '***';
+  return `${masked}@${domain}`;
+}
+
 export default function CheckMail() {
   const { data: session } = useSession();
   const downSM = useMediaQuery((theme) => theme.breakpoints.down('sm'));
+  const searchParams = useSearchParams();
+  const rawEmail = searchParams.get('email');
+  const displayEmail = rawEmail ? maskEmail(decodeURIComponent(rawEmail)) : null;
 
   return (
     <AuthWrapper>
@@ -30,7 +41,7 @@ export default function CheckMail() {
           <Box sx={{ mb: { xs: -0.5, sm: 0.5 } }}>
             <Typography variant="h3">Hi, Check Your Mail</Typography>
             <Typography color="secondary" sx={{ mb: 0.5, mt: 1.25 }}>
-              We have sent a password recover instructions to your email.
+              We have sent password recovery instructions{displayEmail ? ` to ${displayEmail}` : ' to your email'}.
             </Typography>
           </Box>
         </Grid>

--- a/src/views/auth/check-mail.tsx
+++ b/src/views/auth/check-mail.tsx
@@ -32,7 +32,15 @@ export default function CheckMail() {
   const downSM = useMediaQuery((theme) => theme.breakpoints.down('sm'));
   const searchParams = useSearchParams();
   const rawEmail = searchParams.get('email');
-  const displayEmail = rawEmail ? maskEmail(decodeURIComponent(rawEmail)) : null;
+  let decodedEmail: string | null = null;
+  if (rawEmail) {
+    try {
+      decodedEmail = decodeURIComponent(rawEmail);
+    } catch {
+      decodedEmail = rawEmail; // fallback if malformed URI
+    }
+  }
+  const displayEmail = decodedEmail ? maskEmail(decodedEmail) : null;
 
   return (
     <AuthWrapper>


### PR DESCRIPTION
## Summary
Wires the existing Forgot Password UI to the backend API using RTK Query. No design changes were made.

## Changes

**`src/store/api/authApi.ts`** (new)
- Created RTK Query endpoint slice extending `baseApi`
- `forgotPassword` mutation → `POST /auth/forgot-password`
- Exports `useForgotPasswordMutation`

**`src/sections/auth/auth-forms/AuthForgotPassword.tsx`** (updated)
- Replaced stub `onSubmit` with real API call via `useForgotPasswordMutation`
- On success: shows snackbar + redirects to `/check-mail?email=...`
- On error: displays inline error message under the form

**`src/views/auth/check-mail.tsx`** (updated)
- Reads `?email=` query param from URL
- Displays masked email address (e.g. `te***@example.com`) in the subtitle

## Flow
/forget-pass → POST /auth/forgot-password → /check-mail → user clicks email link → /reset-password?token=...